### PR TITLE
Add option to create arbitrary RBAC rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,11 @@
 parameters:
   rbac:
     =_metadata: {}
-    namespace: syn-rbac
+
+    namespace: default
+    manageNamespace: false
+
+
     serviceaccounts: {}
     clusterroles: {}
     clusterrolebindings: {}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,4 +10,4 @@ parameters:
     clusterroles: {}
     clusterrolebindings: {}
     roles: {}
-    rolebinding: {}
+    rolebindings: {}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,3 +2,8 @@ parameters:
   rbac:
     =_metadata: {}
     namespace: syn-rbac
+    serviceaccounts: {}
+    clusterroles: {}
+    clusterrolebindings: {}
+    roles: {}
+    rolebinding: {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -68,8 +68,8 @@ local processRoleBinding(rb) = rb {
     +
     [ {
       kind: 'ServiceAccount',
-      namespace: namespacedName(sa).namespace,
-      name: namespacedName(sa).name,
+      namespace: namespacedName(sa, namespace=rb.metadata.namespace).namespace,
+      name: namespacedName(sa, namespace=rb.metadata.namespace).name,
     } for sa in com.renderArray(extraSubjects.serviceaccounts) ],
 
 };

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -33,6 +33,25 @@ local processRoleBinding(rb) = rb {
     groups: [],
   } + com.getValueOrDefault(rb, 'subjects_', {}),
 
+  roleRef+:
+    {
+      apiGroup: 'rbac.authorization.k8s.io',
+    }
+    +
+    if std.objectHas(rb, 'role_') && std.objectHas(rb, 'clusterRole_') then error 'cannot specify both "role_" and "clusterRole_"'
+    else if std.objectHas(rb, 'role_') then {
+      kind: 'Role',
+      name: rb.role_,
+    }
+    else if std.objectHas(rb, 'clusterRole_') then {
+      kind: 'ClusterRole',
+      name: rb.clusterRole_,
+    }
+    else {},
+
+  role_:: null,
+  clusterRole_:: null,
+
   subjects_:: null,
   subjects+:
     [ {

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,3 +1,4 @@
+local com = import 'lib/commodore.libjsonnet';
 // main template for rbac
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
@@ -5,6 +6,11 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.rbac;
 
-// Define outputs below
+
 {
+  serviceaccounts: com.generateResources(params.serviceaccounts, kube.ServiceAccount),
+  clusterRoles: com.generateResources(params.clusterroles, kube.ClusterRole),
+  clusterRoleBindings: com.generateResources(params.clusterrolebindings, function(name) kube._Object('rbac.authorization.k8s.io/v1', 'ClusterRoleBinding', name)),
+  roles: com.generateResources(params.roles, kube.Role),
+  roleBindings: com.generateResources(params.rolebindings, function(name) kube._Object('rbac.authorization.k8s.io/v1', 'RoleBinding', name)),
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -76,6 +76,7 @@ local processRoleBinding(rb) = rb {
 
 
 {
+  [if params.manageNamespace then 'namespace']: kube.Namespace(params.namespace),
   serviceaccounts: com.generateResources(
     params.serviceaccounts,
     function(name) kube.ServiceAccount(namespacedName(name).name) {

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -6,11 +6,39 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.rbac;
 
+local namespacedName(name, namespace='') = {
+  local namespacedName = std.splitLimit(name, '/', 1),
+  local ns = if namespace != '' then namespace else params.namespace,
+  namespace: if std.length(namespacedName) > 1 then namespacedName[0] else ns,
+  name: if std.length(namespacedName) > 1 then namespacedName[1] else namespacedName[0],
+};
 
 {
-  serviceaccounts: com.generateResources(params.serviceaccounts, kube.ServiceAccount),
+
+  serviceaccounts: com.generateResources(
+    params.serviceaccounts,
+    function(name) kube.ServiceAccount(namespacedName(name).name) {
+      metadata+: {
+        namespace: namespacedName(name).namespace,
+      },
+    }
+  ),
   clusterRoles: com.generateResources(params.clusterroles, kube.ClusterRole),
   clusterRoleBindings: com.generateResources(params.clusterrolebindings, function(name) kube._Object('rbac.authorization.k8s.io/v1', 'ClusterRoleBinding', name)),
-  roles: com.generateResources(params.roles, kube.Role),
-  roleBindings: com.generateResources(params.rolebindings, function(name) kube._Object('rbac.authorization.k8s.io/v1', 'RoleBinding', name)),
+  roles: com.generateResources(
+    params.roles,
+    function(name) kube.Role(namespacedName(name).name) {
+      metadata+: {
+        namespace: namespacedName(name).namespace,
+      },
+    }
+  ),
+  roleBindings: com.generateResources(
+    params.rolebindings,
+    function(name) kube._Object('rbac.authorization.k8s.io/v1', 'RoleBinding', namespacedName(name).name) {
+      metadata+: {
+        namespace: namespacedName(name).namespace,
+      },
+    }
+  ),
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -60,15 +60,18 @@ type:: dict
 default:: {}
 
 The `roles` and `clusterroles` keys generally expose the same parameters.
-The `roles` parameter can be used to create a list oI guess de bastel https://github.com/madduck/reclass/commit/05cfd74a0df98a9f37580c05de381d54a4cfe688f arbitrary roles, while the `clusterroles` parameter can create arbitrary cluster roles.
+The `roles` parameter can be used to create arbitrary roles, while the `clusterroles` parameter can create arbitrary cluster roles.
 
-The keys of the `roles` are parsed as namespaced names `<namespace>/<name>` and used as names and namespaces of the role.
+The keys of parameter `roles` are parsed as namespaced names `<namespace>/<name>` and used as names and namespaces of the role.
 If no namespace is provided the role is created in the fallback namespace provided in the `namespace` parameter.
-The keys of the `clusterroles` are used as the name of the cluster role.
+The keys of parameter `clusterroles` are used as the name of the cluster role.
 
 The values are directly transformed into `Roles` and `ClusterRoles` resources, but can contain an additonal `rules_` field.
-The content of the `rules_` field is a dict.
-The values of this dict are added to the `rules` list and `apiGroups`, `resources`, or `verbs` that are prefixed with a tilde `~` are removed.
+The content of the `rules_` field is a dict of dicts.
+The keys of the `rules_` dict are ignored by the component, but can be used in the hierarchy to edit existing rules.
+The component looks for keys `apiGroups`, `resources` and `verbs` in each value of the `rules_` dict.
+Each value is transformed into an entry of the role's `rules` list.
+The component expects that the values of fields `apiGroups`, `resources` and `verbs` are lists, and removes entries prefixed with a tilde (`~`) from the final value used for the entry in the role's `rules` list.
 
 This allows to effectively manage and overwrite roles in the configuration hierarchy.
 
@@ -117,7 +120,7 @@ rbac:
 ----
 <1> The verbs and resources prefixed with a tilde `~` are removed from the resulting rule, even if they're configured higher up in the configuration hierarchy.
 
-== `rolebinding` / `clusterrolebindings`
+== `rolebindings` / `clusterrolebindings`
 
 [horizontal]
 type:: dict
@@ -126,9 +129,9 @@ default:: {}
 The `rolebindings` and `clusterrolebindings` keys generally expose the same parameters.
 The `rolebindings` parameter can be used to create a list of arbitrary rolebindings, while the `clusterrolebidings` parameter can create arbitrary cluster rolebindings.
 
-The keys of the `rolebindings` are parsed as namespaced names `<namespace>/<name>` and used as names and namespaces of the rolebinding.
+The keys of parameter `rolebindings` are parsed as namespaced names `<namespace>/<name>` and used as names and namespaces of the rolebinding.
 If no namespace is provided the rolebinding is created in the fallback namespace provided in the `namespace` parameter.
-The keys of the `clusterrolebindings` are used as the name of the cluster rolebinding.
+The keys of parameter `clusterrolebindings` are used as the name of the cluster rolebinding.
 
 The values are directly transformed into `RoleBindings` and `ClusterRoleBindings` resources, but there are additonal helper fields to more effectively manage and overwrite rolebindings in the configuration hierarchy.
 
@@ -138,7 +141,7 @@ The `subjects_` field allows easier management of subjects in the rolebinding.
 The field can contain three lists: `serviceaccounts`, `users`, and `groups`.
 For each entry in the lists a corresponding subject is added to the `subjects` field of the rolebinding resource.
 For serviceaccounts you can specify a namespaced name (`namespace/name`).
-If no namespace is specified the component falls back to the rolebinding or default namespace respectively.
+If no namespace is specified, the component falls back to the rolebinding or default namespace respectively.
 Subjects can be removed from each list by prefixing them with a tilde `~`.
 
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -6,14 +6,250 @@ The parent key for all of the following parameters is `rbac`.
 
 [horizontal]
 type:: string
-default:: `syn-rbac`
+default:: `default`
 
-The namespace in which to deploy this component.
+Fallback namespace to deploy namespaced resources to.
+
+== `manageNamespace`
+
+[horizontal]
+type:: bool
+default:: false
+
+Whether to create/manage the fallback namespace.
+
+== `serviceaccounts`
+
+[horizontal]
+type:: dict
+default:: {}
+
+
+The `serviceaccounts` parameter can be used to create a list of arbitrary sevice accounts.
+
+The provided values are transformed into `ServiceAccount` resources.
+
+The keys are parsed as namespaced names `<namespace>/<name>` and used as names and namespaces of the Service Accounts.
+If no namespace is provided the Service Account is created in the fallback namespace provided in the `namespace` parameter.
+
+
+=== Example
+
+The following example config will result in a `ServiceAccount` `bar` in namespace `foo` and a Service account `buzz` in namespace `syn-sa`.
+
+[source,yaml]
+----
+rbac:
+  namespace: syn-sa
+  serviceaccounts:
+    foo/bar:
+      metadata:
+        labels:
+          foo: "true"
+    buzz:
+      metadata:
+        labels:
+          foo: "false"
+----
+
+
+== `roles` / `clusterroles`
+
+[horizontal]
+type:: dict
+default:: {}
+
+The `roles` and `clusterroles` keys generally expose the same parameters.
+The `roles` parameter can be used to create a list oI guess de bastel https://github.com/madduck/reclass/commit/05cfd74a0df98a9f37580c05de381d54a4cfe688f arbitrary roles, while the `clusterroles` parameter can create arbitrary cluster roles.
+
+The keys of the `roles` are parsed as namespaced names `<namespace>/<name>` and used as names and namespaces of the role.
+If no namespace is provided the role is created in the fallback namespace provided in the `namespace` parameter.
+The keys of the `clusterroles` are used as the name of the cluster role.
+
+The values are directly transformed into `Roles` and `ClusterRoles` resources, but can contain an additonal `rules_` field.
+The content of the `rules_` field is a dict.
+The values of this dict are added to the `rules` list and `apiGroups`, `resources`, or `verbs` that are prefixed with a tilde `~` are removed.
+
+This allows to effectively manage and overwrite roles in the configuration hierarchy.
+
+=== Example
+
+The following example config will result in:
+
+* A `ClusterRole` `ns-creator` that allows to creation of namespaces.
+* A `Role` `cm-deleter` in namespace `foo` that allows the deletion of config maps in that namespace
+* A `Role` `cm-creator` in the default namespace `syn-roles` that allows the creation of config maps.
+
+[source,yaml]
+----
+rbac:
+  namespace: syn-sa
+  clusterroles:
+    ns-creator:
+      rules_:
+        create:
+          apiGroups:
+            - ""
+          resources:
+            - namespaces
+          verbs:
+            - create
+            - ~delete <1>
+  roles:
+    foo/cm-deleter:
+      rules_:
+        delete:
+          apiGroups:
+            - ""
+          resources:
+            - configmaps
+            - ~secrets <1>
+          verbs:
+            - delete
+    cm-creator:
+        create:
+          apiGroups:
+            - ""
+          resources:
+            - configmaps
+          verbs:
+            - create
+----
+<1> The verbs and resources prefixed with a tilde `~` are removed from the resulting rule, even if they're configured higher up in the configuration hierarchy.
+
+== `rolebinding` / `clusterrolebindings`
+
+[horizontal]
+type:: dict
+default:: {}
+
+The `rolebindings` and `clusterrolebindings` keys generally expose the same parameters.
+The `rolebindings` parameter can be used to create a list of arbitrary rolebindings, while the `clusterrolebidings` parameter can create arbitrary cluster rolebindings.
+
+The keys of the `rolebindings` are parsed as namespaced names `<namespace>/<name>` and used as names and namespaces of the rolebinding.
+If no namespace is provided the rolebinding is created in the fallback namespace provided in the `namespace` parameter.
+The keys of the `clusterrolebindings` are used as the name of the cluster rolebinding.
+
+The values are directly transformed into `RoleBindings` and `ClusterRoleBindings` resources, but there are additonal helper fields to more effectively manage and overwrite rolebindings in the configuration hierarchy.
+
+The `role_` and `clusterrole_` field allow you to directly specify the role and clusterrole name respectively as a string, without having to specify `apiGroup` or `kind`.
+
+The `subjects_` field allows easier management of subjects in the rolebinding.
+The field can contain three lists: `serviceaccounts`, `users`, and `groups`.
+For each entry in the lists a corresponding subject is added to the `subjects` field of the rolebinding resource.
+For serviceaccounts you can specify a namespaced name (`namespace/name`).
+If no namespace is specified the component falls back to the rolebinding or default namespace respectively.
+Subjects can be removed from each list by prefixing them with a tilde `~`.
+
+
+=== Example
+
+The following example config will result in:
+
+* A `ClusterRoleBiding` `ns-creator` that binds the `ns-creator` cluster role to user `buzz`, group `org`, and service accounts `bar` in namespace `foo` and `creator` in namespace `syn-sa`.
+* A `RoleBinding` `cm-deleter` in namespace `foo` that binds the role `cm-deleter` in namespace `foo` to user `buzz`, group `org`, and service account `bar` in the namespace `foo`.
+* A `RoleBinding` `cm-editor` in namespace `syn-sa` that binds the cluster role `cm-editor` to user `buzz`, group `org`, and service account `buzz` in the namespace `syn-sa`.
+
+[source,yaml]
+----
+rbac:
+  namespace: syn-sa
+  clusterrolebindings:
+    ns-creator:
+      clusterRole_: ns-creator
+      subjects_:
+        serviceaccounts:
+          - foo/bar
+          - creator
+        users:
+          - buzz
+          - ~blib
+        groups:
+          - org
+          - ~root
+  rolebindings:
+    foo/cm-deleter:
+      role_: cm-deleter
+      subjects_:
+        serviceaccounts:
+          - bar
+        users:
+          - buzz
+        groups:
+          - org
+    cm-editor:
+      clusterRole_: cm-editor
+      subjects_:
+        serviceaccounts:
+          - buzz
+        users:
+          - buzz
+        groups:
+          - org
+----
+
 
 
 == Example
 
+The following complete example will:
+
+* Create and manage namespace `example-service-accounts`
+* Create a `ServiceAccount` `bar` in namespace `foo`.
+* Gives the `ServiceAccount` `bar` the permission to create namespaces
+* Gives the `ServiceAccount` `bar`, user `tim`, and group `org` the permission to manage `ConfigMaps` in namespace `foo`
+
 [source,yaml]
 ----
-namespace: example-namespace
+rbac:
+  namespace: example-service-accounts
+  manageNamespace: true
+
+  serviceaccounts:
+    foo/bar:
+      metadata:
+        labels:
+          foo: "true"
+
+  clusterroles:
+    ns-creator:
+      rules_:
+        create:
+          apiGroups:
+            - ""
+          resources:
+            - namespaces
+          verbs:
+            - create
+  clusterrolebindings:
+    ns-creator:
+      clusterRole_: ns-creator
+      subjects_:
+        serviceaccounts:
+          - foo/bar
+
+  roles:
+    foo/cm-admin:
+      rules_:
+        delete:
+          apiGroups:
+            - ""
+          resources:
+            - configmaps
+          verbs:
+            - get
+            - create
+            - update
+            - patch
+            - delete
+  rolebindings:
+    foo/cm-admin:
+      role_: cm-deleter
+      subjects_:
+        serviceaccounts:
+          - bar
+        users:
+          - tim
+        groups:
+          - org
 ----

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -75,6 +75,9 @@ The component expects that the values of fields `apiGroups`, `resources` and `ve
 
 This allows to effectively manage and overwrite roles in the configuration hierarchy.
 
+NOTE: Other provided keys, such as `metadata`, are added to the role as-is.
+This includes `rules` which added as is to the rules specified in `rules_`.
+
 === Example
 
 The following example config will result in:
@@ -110,6 +113,7 @@ rbac:
           verbs:
             - delete
     cm-creator:
+      rules_:
         create:
           apiGroups:
             - ""
@@ -144,6 +148,8 @@ For serviceaccounts you can specify a namespaced name (`namespace/name`).
 If no namespace is specified, the component falls back to the rolebinding or default namespace respectively.
 Subjects can be removed from each list by prefixing them with a tilde `~`.
 
+NOTE: Other provided keys, such as `metadata`, are added to the rolebinding as-is.
+This includes `subjects` which added as-is to the subjects specified in `subjects_`.
 
 === Example
 

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -34,6 +34,21 @@ parameters:
           - kind: ServiceAccount
             name: bar
             namespace: foo
+      helper:
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: helper
+        subjects_:
+          serviceaccounts:
+            - foo/bar
+            - ~foo/buz
+          users:
+            - buzz
+            - ~blib
+          groups:
+            - org
+            - ~root
     roles:
       foo/raw:
         rules:
@@ -63,3 +78,19 @@ parameters:
           - kind: ServiceAccount
             name: bar
             namespace: foo
+      foo/helper:
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: Role
+          name: helper
+        subjects_:
+          serviceaccounts:
+            - foo/bar
+            - ~foo/buz
+          users:
+            - buzz
+            - ~blib
+          groups:
+            - org
+            - ~root
+

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,9 +1,8 @@
 parameters:
   rbac:
     serviceaccounts:
-      bar:
+      foo/bar:
         metadata:
-          namespace: foo
           labels:
             foo: "false"
     clusterroles:
@@ -26,9 +25,7 @@ parameters:
             name: bar
             namespace: foo
     roles:
-      raw:
-        metadata:
-          namespace: foo
+      foo/raw:
         rules:
           - apiGroups:
               - ""
@@ -37,13 +34,11 @@ parameters:
             verbs:
               - create
     rolebindings:
-      raw:
+      foo/raw:
         roleRef:
           apiGroup: rbac.authorization.k8s.io
           kind: Role
           name: raw
-        metadata:
-          namespace: foo
         subjects:
           - kind: ServiceAccount
             name: bar

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -14,6 +14,16 @@ parameters:
               - namespaces
             verbs:
               - create
+      helper:
+        rules_:
+          create:
+            apiGroups:
+              - ""
+            resources:
+              - namespaces
+            verbs:
+              - create
+              - ~delete 
     clusterrolebindings:
       raw:
         roleRef:
@@ -33,6 +43,16 @@ parameters:
               - configmaps
             verbs:
               - create
+      foo/helper:
+        rules_:
+          create:
+            apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - create
+              - ~delete 
     rolebindings:
       foo/raw:
         roleRef:

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -83,7 +83,7 @@ parameters:
         role_: helper
         subjects_:
           serviceaccounts:
-            - foo/bar
+            - bar
             - ~foo/buz
           users:
             - buzz

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,3 +1,50 @@
-# Overwrite parameters here
-
-# parameters: {...}
+parameters:
+  rbac:
+    serviceaccounts:
+      bar:
+        metadata:
+          namespace: foo
+          labels:
+            foo: "false"
+    clusterroles:
+      raw:
+        rules:
+          - apiGroups:
+              - ""
+            resources:
+              - namespaces
+            verbs:
+              - create
+    clusterrolebindings:
+      raw:
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: raw
+        subjects:
+          - kind: ServiceAccount
+            name: bar
+            namespace: foo
+    roles:
+      raw:
+        metadata:
+          namespace: foo
+        rules:
+          - apiGroups:
+              - ""
+            resources:
+              - configmaps
+            verbs:
+              - create
+    rolebindings:
+      raw:
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: Role
+          name: raw
+        metadata:
+          namespace: foo
+        subjects:
+          - kind: ServiceAccount
+            name: bar
+            namespace: foo

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -23,7 +23,7 @@ parameters:
               - namespaces
             verbs:
               - create
-              - ~delete 
+              - ~delete
     clusterrolebindings:
       raw:
         roleRef:
@@ -35,10 +35,7 @@ parameters:
             name: bar
             namespace: foo
       helper:
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: helper
+        clusterRole_: helper
         subjects_:
           serviceaccounts:
             - foo/bar
@@ -67,7 +64,7 @@ parameters:
               - configmaps
             verbs:
               - create
-              - ~delete 
+              - ~delete
     rolebindings:
       foo/raw:
         roleRef:
@@ -79,10 +76,7 @@ parameters:
             name: bar
             namespace: foo
       foo/helper:
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: Role
-          name: helper
+        role_: helper
         subjects_:
           serviceaccounts:
             - foo/bar
@@ -93,4 +87,3 @@ parameters:
           groups:
             - org
             - ~root
-

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,10 +1,14 @@
 parameters:
   rbac:
+    namespace: syn-serviceaccounts
+    manageNamespace: true
+
     serviceaccounts:
       foo/bar:
         metadata:
           labels:
             foo: "false"
+      buzz: {}
     clusterroles:
       raw:
         rules:

--- a/tests/golden/defaults/rbac/rbac/clusterRoleBindings.yaml
+++ b/tests/golden/defaults/rbac/rbac/clusterRoleBindings.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: raw
+  name: raw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: raw
+subjects:
+  - kind: ServiceAccount
+    name: bar
+    namespace: foo

--- a/tests/golden/defaults/rbac/rbac/clusterRoleBindings.yaml
+++ b/tests/golden/defaults/rbac/rbac/clusterRoleBindings.yaml
@@ -3,6 +3,28 @@ kind: ClusterRoleBinding
 metadata:
   annotations: {}
   labels:
+    name: helper
+  name: helper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: helper
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: org
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: buzz
+  - kind: ServiceAccount
+    name: bar
+    namespace: foo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
     name: raw
   name: raw
 roleRef:

--- a/tests/golden/defaults/rbac/rbac/clusterRoles.yaml
+++ b/tests/golden/defaults/rbac/rbac/clusterRoles.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: raw
+  name: raw
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - create

--- a/tests/golden/defaults/rbac/rbac/clusterRoles.yaml
+++ b/tests/golden/defaults/rbac/rbac/clusterRoles.yaml
@@ -3,6 +3,21 @@ kind: ClusterRole
 metadata:
   annotations: {}
   labels:
+    name: helper
+  name: helper
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
     name: raw
   name: raw
 rules:

--- a/tests/golden/defaults/rbac/rbac/namespace.yaml
+++ b/tests/golden/defaults/rbac/rbac/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-serviceaccounts
+  name: syn-serviceaccounts

--- a/tests/golden/defaults/rbac/rbac/roleBindings.yaml
+++ b/tests/golden/defaults/rbac/rbac/roleBindings.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: raw
+  name: raw
+  namespace: foo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: raw
+subjects:
+  - kind: ServiceAccount
+    name: bar
+    namespace: foo

--- a/tests/golden/defaults/rbac/rbac/roleBindings.yaml
+++ b/tests/golden/defaults/rbac/rbac/roleBindings.yaml
@@ -3,6 +3,29 @@ kind: RoleBinding
 metadata:
   annotations: {}
   labels:
+    name: helper
+  name: helper
+  namespace: foo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: helper
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: org
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: buzz
+  - kind: ServiceAccount
+    name: bar
+    namespace: foo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
     name: raw
   name: raw
   namespace: foo

--- a/tests/golden/defaults/rbac/rbac/roles.yaml
+++ b/tests/golden/defaults/rbac/rbac/roles.yaml
@@ -3,6 +3,22 @@ kind: Role
 metadata:
   annotations: {}
   labels:
+    name: helper
+  name: helper
+  namespace: foo
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
     name: raw
   name: raw
   namespace: foo

--- a/tests/golden/defaults/rbac/rbac/roles.yaml
+++ b/tests/golden/defaults/rbac/rbac/roles.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: raw
+  name: raw
+  namespace: foo
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create

--- a/tests/golden/defaults/rbac/rbac/serviceaccounts.yaml
+++ b/tests/golden/defaults/rbac/rbac/serviceaccounts.yaml
@@ -3,6 +3,15 @@ kind: ServiceAccount
 metadata:
   annotations: {}
   labels:
+    name: buzz
+  name: buzz
+  namespace: syn-serviceaccounts
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
     foo: 'false'
     name: bar
   name: bar

--- a/tests/golden/defaults/rbac/rbac/serviceaccounts.yaml
+++ b/tests/golden/defaults/rbac/rbac/serviceaccounts.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    foo: 'false'
+    name: bar
+  name: bar
+  namespace: foo


### PR DESCRIPTION
This PR adds a fairly generic way to create arbitrary `ServiceAccounts`, `(Cluster)Rolebindings`, and `(Cluster)Roles`.

I was unsure how much magic to add and opted for a more conservative approach and added only the magic needed to make overwriting configuration possible (and some namespaced names).

Even with the comparatively low amount of magic I had a hard time documenting this in a readable way, input is welcome.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
