### PR TITLE
Generate ServiceAccount API token secrets

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -88,6 +88,18 @@ local processRoleBinding(rb) = rb {
       },
     }
   ),
+  serviceaccount_tokens: com.generateResources(
+    params.serviceaccounts,
+    function(name) kube.Secret(namespacedName(name).name) {
+      metadata+: {
+        namespace: namespacedName(name).namespace,
+        annotations: {
+          'kubernetes.io/service-account.name': namespacedName(name).name,
+        },
+      },
+      type: 'kubernetes.io/service-account-token',
+    },
+  ),
   clusterRoles: [
     processRole(cr)
     for cr in com.generateResources(params.clusterroles, kube.ClusterRole)

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,5 @@
 = rbac
 
-rbac is a Commodore component to manage rbac.
+This component enables users to define arbitrary ServiceAccounts and RBAC rules through the Project Syn hierarchy.
 
 See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -32,6 +32,8 @@ The provided values are transformed into `ServiceAccount` resources.
 The keys are parsed as namespaced names `<namespace>/<name>` and used as names and namespaces of the Service Accounts.
 If no namespace is provided the Service Account is created in the fallback namespace provided in the `namespace` parameter.
 
+The component also creates an https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token[API token secret] for each specified service account.
+This ensures that users can fetch a long-lived token associated with the service account on Kubernetes 1.24+.
 
 === Example
 

--- a/tests/golden/defaults/rbac/rbac/serviceaccount_tokens.yaml
+++ b/tests/golden/defaults/rbac/rbac/serviceaccount_tokens.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: buzz
+  labels:
+    name: buzz
+  name: buzz
+  namespace: syn-serviceaccounts
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: bar
+  labels:
+    foo: 'false'
+    name: bar
+  name: bar
+  namespace: foo
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
Explicitly create an API token secret for each service account defined in the hierarchy. This ensures that users can create ServiceAccounts and associated long-lived API tokens for purposes like CD pipelines through this component on Kubernetes 1.24+.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
