### PR TITLE
Support dynamic Roles and RoleBindings

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,7 +14,11 @@ parameters:
 
     namespaceSync:
       ignoreNames: []
-      ignorePrefixes: []
+      ignorePrefixes:
+        - kube
+        - openshift
+        - appuio
+        - syn
       labelPrefix: set.rbac.syn.tools/
       policies: {}
       policySets: {}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,9 +6,15 @@ parameters:
     namespace: default
     manageNamespace: false
 
-
     serviceaccounts: {}
     clusterroles: {}
     clusterrolebindings: {}
     roles: {}
     rolebindings: {}
+
+    namespaceSync:
+      ignoreNames: []
+      ignorePrefixes: []
+      labelPrefix: set.rbac.syn.tools/
+      policies: {}
+      policySets: {}

--- a/class/rbac.yml
+++ b/class/rbac.yml
@@ -7,5 +7,6 @@ parameters:
         output_path: .
       - input_paths:
           - ${_base_directory}/component/main.jsonnet
+          - ${_base_directory}/component/espejote.jsonnet
         input_type: jsonnet
         output_path: rbac/

--- a/component/espejote-templates/rbac-sync.jsonnet
+++ b/component/espejote-templates/rbac-sync.jsonnet
@@ -1,0 +1,135 @@
+local esp = import 'espejote.libsonnet';
+local config = import 'lib/espejote-rbac-sync/config.json';
+
+local context = esp.context();
+
+local activePoliciesAnnotation = 'rbac.syn.tools/active-policies';
+
+// Extract the active policy sets from the given namespace object,
+// based on the annotations applied by this ManagedResource.
+local activePolicies(namespace) =
+  local rawSet = std.get(std.get(namespace.metadata, 'annotations', {}), activePoliciesAnnotation, '[]');
+  std.set(std.parseJson(rawSet));
+
+// Extract the desired policy sets from the given namespace object,
+// Returns an empty array if the namespace is in the ignoredNamespaces list.
+// If no policy sets are set by labels, no policy sets are returned.
+// If any policy set labels are set, those are returned.
+//   ignoredNamespaces / no-defaults label -> []
+//   no policy set labels -> [ ]
+//   policy set labels -> [ <policy sets from labels> ]
+local desiredPolicySets(namespace) =
+  local objHasLabel(obj, label) =
+    std.objectHas(std.get(obj.metadata, 'labels', {}), label);
+
+  // Policy sets based on labels starting with params.namespaceSync.labelPrefix.
+  //   labels:
+  //     set.example.io/airlock: ""
+  //     set.example.io/myapp: ""
+  // would return the policy sets `["airlock", "myapp"]`.
+  // The configured prefix is suffixed with a '/' if it does not already end with one.
+  local policySetsFromLabel =
+    local prefix = if std.endsWith(config.labelPrefix, '/') then
+      config.labelPrefix
+    else
+      config.labelPrefix + '/';
+
+    [
+      lbl[std.length(prefix):]
+      for lbl in std.objectFields(std.get(namespace.metadata, 'labels', {}))
+      if std.startsWith(lbl, prefix)
+    ];
+
+  if std.member(config.ignoreNames, namespace.metadata.name) then
+    []
+  else if std.length(std.filter(
+    function(prefix) std.startsWith(namespace.metadata.name, prefix),
+    config.ignorePrefixes
+  )) > 0 then
+    []
+  else if std.length(policySetsFromLabel) > 0 then
+    std.set(policySetsFromLabel)
+  else
+    [];
+
+local isRole(policyName) =
+  std.startsWith(policyName, 'role/');
+local isRoleBinding(policyName) =
+  std.startsWith(policyName, 'rolebinding/');
+
+// Generate policy sets.
+local generatePolicy(policyName, namespace) =
+  config.policies[policyName] {
+    metadata+: {
+      namespace: namespace.metadata.name,
+    },
+  };
+
+local purgePolicy(policyName, namespace) =
+  esp.markForDelete(generatePolicy(policyName, namespace));
+
+// Reconcile the given namespace.
+local reconcileNamespace(namespace) =
+  local desiredPolicies = std.set(std.filter(
+    function(policy) std.get(config.policies, policy) != null,
+    std.flattenArrays([
+      config.policySets[set]
+      for set in desiredPolicySets(namespace)
+      if std.get(config.policySets, set) != null
+    ])
+  ));
+  // Generate array of RBAC policies for the given policy set.
+  [
+    generatePolicy(policy, namespace)
+    for policy in desiredPolicies
+  ]
+  // Generate array of RBAC policies to be deleted for the given policy set.
+  +
+  [
+    purgePolicy(policy, namespace)
+    for policy in std.setDiff(activePolicies(namespace), desiredPolicies)
+  ]
+  // Generate annotation for the given namespace containing the new active policy sets.
+  +
+  [ {
+    apiVersion: 'v1',
+    kind: 'Namespace',
+    metadata: {
+      annotations: {
+        [activePoliciesAnnotation]: std.manifestJsonMinified(desiredPolicies),
+      },
+      name: namespace.metadata.name,
+    },
+  } ];
+
+// check if the object is getting deleted by checking if it has
+// `metadata.deletionTimestamp`.
+local inDelete(obj) = std.get(obj.metadata, 'deletionTimestamp', '') != '';
+
+// Do the thing
+if esp.triggerName() == 'namespace' then (
+  // Handle single namespace update on namespace trigger
+  local nsTrigger = esp.triggerData();
+  // nsTrigger.resource can be null if we're called when the namespace is getting
+  // deleted. If it's not null, we still don't want to do anything when the
+  // namespace is getting deleted.
+  if nsTrigger.resource != null && !inDelete(nsTrigger.resource) then
+    reconcileNamespace(nsTrigger.resource)
+) else if esp.triggerName() == 'role' || esp.triggerName() == 'rolebinding' then (
+  // Handle single namespace update on role or rolebinding trigger
+  local namespace = esp.triggerData().resourceEvent.namespace;
+  std.flattenArrays([
+    reconcileNamespace(ns)
+    for ns in context.namespaces
+    if ns.metadata.name == namespace && !inDelete(ns)
+  ])
+) else (
+  // Reconcile all namespaces for jsonnetlibrary update or managedresource
+  // reconcile.
+  local namespaces = context.namespaces;
+  std.flattenArrays([
+    reconcileNamespace(ns)
+    for ns in namespaces
+    if !inDelete(ns)
+  ])
+)

--- a/component/espejote.jsonnet
+++ b/component/espejote.jsonnet
@@ -1,0 +1,192 @@
+local com = import 'lib/commodore.libjsonnet';
+local esp = import 'lib/espejote.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local utils = import 'utils.libsonnet';
+
+// The hiera parameters for the component
+local inv = kap.inventory();
+local params = inv.parameters.rbac;
+
+local espNamespace = inv.parameters.espejote.namespace;
+local mrName = 'espejote-rbac-sync';
+local rbacName = 'espejote-managedresource-rbac-sync';
+
+// RBAC for Espejote
+local espejoteRBAC = [
+  {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      labels: {
+        'app.kubernetes.io/component': 'rbac',
+        'app.kubernetes.io/name': mrName,
+      },
+      name: mrName,
+      namespace: espNamespace,
+    },
+  },
+  {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'ClusterRoleBinding',
+    metadata: {
+      labels: {
+        'app.kubernetes.io/component': 'rbac',
+        'app.kubernetes.io/name': rbacName,
+      },
+      name: rbacName,
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'cluster-admin',
+    },
+    subjects: [
+      {
+        kind: 'ServiceAccount',
+        name: mrName,
+        namespace: espNamespace,
+      },
+    ],
+  },
+];
+
+// Espejote resources
+local _rbacAnnotations = {
+  'syn.tools/source': 'https://github.com/projectsyn/component-rbac.git',
+};
+local _rbacLabels = {
+  'app.kubernetes.io/managed-by': 'espejote',
+  'app.kubernetes.io/part-of': 'syn',
+  'app.kubernetes.io/component': 'rbac',
+};
+
+local prefixToKind(name) =
+  if std.startsWith(name, 'role/') then 'Role'
+  else if std.startsWith(name, 'rolebinding/') then 'RoleBinding'
+  // else if std.startsWith(name, 'serviceaccount/') then 'ServiceAccount'
+  else error 'Only prefixes "role/" and "rolebinding/" are supported.';
+local suffixToName(name) = std.splitLimit(name, '/', 1)[1];
+
+local jsonnetLibrary = esp.jsonnetLibrary(mrName, espNamespace) {
+  spec: {
+    data: {
+      'config.json': std.manifestJson({
+        // Ignore namespaces by name or prefix
+        ignoreNames: com.renderArray(params.namespaceSync.ignoreNames),
+        ignorePrefixes: com.renderArray(params.namespaceSync.ignorePrefixes),
+        // Policies and PolicySets
+        labelPrefix: params.namespaceSync.labelPrefix,
+        policies: {
+          [policy]: {
+                      apiVersion: 'rbac.authorization.k8s.io/v1',
+                      kind: prefixToKind(policy),
+                      metadata+: {
+                        annotations: _rbacAnnotations,
+                        labels: _rbacLabels,
+                        name: suffixToName(policy),
+                      },
+                    } +
+                    if prefixToKind(policy) == 'Role' then utils.processRole(params.namespaceSync.policies[policy])
+                    else if prefixToKind(policy) == 'RoleBinding' then utils.processRoleBinding(params.namespaceSync.policies[policy])
+                    else {}
+          for policy in std.objectFields(params.namespaceSync.policies)
+          if params.namespaceSync.policies[policy] != null
+        },
+        policySets: {
+          [set]: com.renderArray(params.namespaceSync.policySets[set])
+          for set in std.objectFields(params.namespaceSync.policySets)
+          if params.namespaceSync.policySets[set] != null
+        },
+      }),
+    },
+  },
+};
+
+local managedResource = esp.managedResource(mrName, espNamespace) {
+  metadata+: {
+    annotations: {
+      'syn.tools/description': |||
+        Manages Roles and RoleBindings based on namespace labels.
+
+        To customize the applied RBAC policies, you can use labels on namespaces to select
+        additional policy sets. See https://hub.syn.tools/rbac/index.html for details.
+      |||,
+    },
+  },
+  spec: {
+    context: [
+      {
+        name: 'namespaces',
+        resource: {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+        },
+      },
+    ],
+    triggers: [
+      {
+        name: 'jslib',
+        watchResource: {
+          apiVersion: jsonnetLibrary.apiVersion,
+          kind: 'JsonnetLibrary',
+          name: jsonnetLibrary.metadata.name,
+          namespace: jsonnetLibrary.metadata.namespace,
+        },
+      },
+      {
+        name: 'namespace',
+        watchContextResource: {
+          name: 'namespaces',
+        },
+      },
+      {
+        name: 'role',
+        watchResource: {
+          apiVersion: 'rbac.authorization.k8s.io/v1',
+          kind: 'Role',
+          labelSelector: {
+            matchLabels: _rbacLabels,
+          },
+          namespace: '',
+        },
+      },
+      {
+        name: 'rolebinding',
+        watchResource: {
+          apiVersion: 'rbac.authorization.k8s.io/v1',
+          kind: 'RoleBinding',
+          labelSelector: {
+            matchLabels: _rbacLabels,
+          },
+          namespace: '',
+        },
+      },
+    ],
+    serviceAccountRef: {
+      name: espejoteRBAC[0].metadata.name,
+    },
+    applyOptions: {
+      force: true,
+    },
+    template: importstr 'espejote-templates/rbac-sync.jsonnet',
+  },
+};
+
+// Check if espejote is installed and resources are configured
+local hasEspejote = std.member(inv.applications, 'espejote');
+local hasPolicySets = std.length(params.namespaceSync.policySets) > 0;
+
+// Define outputs below
+if hasPolicySets && hasEspejote then
+  {
+    espejote_rbac: espejoteRBAC,
+    espejote_lib: jsonnetLibrary,
+    espejote_mr: managedResource,
+  }
+else if hasPolicySets then
+  std.trace(
+    'espejote must be installed',
+    {}
+  )
+else {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,100 +1,29 @@
 local com = import 'lib/commodore.libjsonnet';
-// main template for rbac
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local utils = import 'utils.libsonnet';
 local inv = kap.inventory();
+
 // The hiera parameters for the component
 local params = inv.parameters.rbac;
-
-local namespacedName(name, namespace='') = {
-  local namespacedName = std.splitLimit(name, '/', 1),
-  local ns = if namespace != '' then namespace else params.namespace,
-  namespace: if std.length(namespacedName) > 1 then namespacedName[0] else ns,
-  name: if std.length(namespacedName) > 1 then namespacedName[1] else namespacedName[0],
-};
-
-
-local processRole(r) = r {
-  local extraRules = std.objectValues(
-    com.getValueOrDefault(r, 'rules_', {})
-  ),
-  rules_:: null,
-  rules+: [ {
-    apiGroups: com.renderArray(rule.apiGroups),
-    resources: com.renderArray(rule.resources),
-    verbs: com.renderArray(rule.verbs),
-  } for rule in extraRules ],
-};
-
-local processRoleBinding(rb) = rb {
-  local extraSubjects = {
-    users: [],
-    serviceaccounts: [],
-    groups: [],
-  } + com.getValueOrDefault(rb, 'subjects_', {}),
-
-  local rbNs = com.getValueOrDefault(rb.metadata, 'namespace', ''),
-
-
-  roleRef+:
-    {
-      apiGroup: 'rbac.authorization.k8s.io',
-    }
-    +
-    if std.objectHas(rb, 'role_') && std.objectHas(rb, 'clusterRole_') then error 'cannot specify both "role_" and "clusterRole_"'
-    else if std.objectHas(rb, 'role_') then {
-      kind: 'Role',
-      name: rb.role_,
-    }
-    else if std.objectHas(rb, 'clusterRole_') then {
-      kind: 'ClusterRole',
-      name: rb.clusterRole_,
-    }
-    else {},
-
-  role_:: null,
-  clusterRole_:: null,
-
-  subjects_:: null,
-  subjects+:
-    [ {
-      apiGroup: 'rbac.authorization.k8s.io',
-      kind: 'Group',
-      name: g,
-    } for g in com.renderArray(extraSubjects.groups) ]
-    +
-    [ {
-      apiGroup: 'rbac.authorization.k8s.io',
-      kind: 'User',
-      name: u,
-    } for u in com.renderArray(extraSubjects.users) ]
-    +
-    [ {
-      kind: 'ServiceAccount',
-      namespace: namespacedName(sa, namespace=rbNs).namespace,
-      name: namespacedName(sa, namespace=rbNs).name,
-    } for sa in com.renderArray(extraSubjects.serviceaccounts) ],
-
-};
-
 
 {
   [if params.manageNamespace then 'namespace']: kube.Namespace(params.namespace),
   serviceaccounts: com.generateResources(
     params.serviceaccounts,
-    function(name) kube.ServiceAccount(namespacedName(name).name) {
+    function(name) kube.ServiceAccount(utils.namespacedName(name).name) {
       metadata+: {
-        namespace: namespacedName(name).namespace,
+        namespace: utils.namespacedName(name).namespace,
       },
     }
   ),
   serviceaccount_tokens: com.generateResources(
     params.serviceaccounts,
-    function(name) kube.Secret(namespacedName(name).name) {
+    function(name) kube.Secret(utils.namespacedName(name).name) {
       metadata+: {
-        namespace: namespacedName(name).namespace,
+        namespace: utils.namespacedName(name).namespace,
         annotations: {
-          'kubernetes.io/service-account.name': namespacedName(name).name,
+          'kubernetes.io/service-account.name': utils.namespacedName(name).name,
         },
       },
       // Ensure empty `data` field is omitted so that ArgoCD doesn't get
@@ -104,32 +33,32 @@ local processRoleBinding(rb) = rb {
     },
   ),
   clusterRoles: [
-    processRole(cr)
+    utils.processRole(cr)
     for cr in com.generateResources(params.clusterroles, kube.ClusterRole)
   ],
   clusterRoleBindings: [
-    processRoleBinding(crb)
+    utils.processRoleBinding(crb)
     for crb in
       com.generateResources(params.clusterrolebindings, function(name) kube._Object('rbac.authorization.k8s.io/v1', 'ClusterRoleBinding', name))
   ],
   roles: [
-    processRole(r)
+    utils.processRole(r)
     for r in com.generateResources(
       params.roles,
-      function(name) kube.Role(namespacedName(name).name) {
+      function(name) kube.Role(utils.namespacedName(name).name) {
         metadata+: {
-          namespace: namespacedName(name).namespace,
+          namespace: utils.namespacedName(name).namespace,
         },
       }
     )
   ],
   roleBindings: [
-    processRoleBinding(rb)
+    utils.processRoleBinding(rb)
     for rb in com.generateResources(
       params.rolebindings,
-      function(name) kube._Object('rbac.authorization.k8s.io/v1', 'RoleBinding', namespacedName(name).name) {
+      function(name) kube._Object('rbac.authorization.k8s.io/v1', 'RoleBinding', utils.namespacedName(name).name) {
         metadata+: {
-          namespace: namespacedName(name).namespace,
+          namespace: utils.namespacedName(name).namespace,
         },
       }
     )

--- a/component/utils.libsonnet
+++ b/component/utils.libsonnet
@@ -1,0 +1,81 @@
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local inv = kap.inventory();
+
+// The hiera parameters for the component
+local params = inv.parameters.rbac;
+
+local namespacedName(name, namespace='') = {
+  local namespacedName = std.splitLimit(name, '/', 1),
+  local ns = if namespace != '' then namespace else params.namespace,
+  namespace: if std.length(namespacedName) > 1 then namespacedName[0] else ns,
+  name: if std.length(namespacedName) > 1 then namespacedName[1] else namespacedName[0],
+};
+
+local processRole(r) = r {
+  local extraRules = std.objectValues(
+    com.getValueOrDefault(r, 'rules_', {})
+  ),
+  rules_:: null,
+  rules+: [ {
+    apiGroups: com.renderArray(rule.apiGroups),
+    resources: com.renderArray(rule.resources),
+    verbs: com.renderArray(rule.verbs),
+  } for rule in extraRules ],
+};
+
+local processRoleBinding(rb) = rb {
+  local extraSubjects = {
+    users: [],
+    serviceaccounts: [],
+    groups: [],
+  } + com.getValueOrDefault(rb, 'subjects_', {}),
+
+  local rbNs = com.getValueOrDefault(rb.metadata, 'namespace', ''),
+
+
+  roleRef+:
+    {
+      apiGroup: 'rbac.authorization.k8s.io',
+    }
+    +
+    if std.objectHas(rb, 'role_') && std.objectHas(rb, 'clusterRole_') then error 'cannot specify both "role_" and "clusterRole_"'
+    else if std.objectHas(rb, 'role_') then {
+      kind: 'Role',
+      name: rb.role_,
+    }
+    else if std.objectHas(rb, 'clusterRole_') then {
+      kind: 'ClusterRole',
+      name: rb.clusterRole_,
+    }
+    else {},
+
+  role_:: null,
+  clusterRole_:: null,
+
+  subjects_:: null,
+  subjects+:
+    [ {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'Group',
+      name: g,
+    } for g in com.renderArray(extraSubjects.groups) ]
+    +
+    [ {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'User',
+      name: u,
+    } for u in com.renderArray(extraSubjects.users) ]
+    +
+    [ {
+      kind: 'ServiceAccount',
+      namespace: namespacedName(sa, namespace=rbNs).namespace,
+      name: namespacedName(sa, namespace=rbNs).name,
+    } for sa in com.renderArray(extraSubjects.serviceaccounts) ],
+};
+
+{
+  namespacedName: namespacedName,
+  processRole: processRole,
+  processRoleBinding: processRoleBinding,
+}

--- a/docs/modules/ROOT/pages/how-tos/using-customizing-policies.adoc
+++ b/docs/modules/ROOT/pages/how-tos/using-customizing-policies.adoc
@@ -1,0 +1,95 @@
+= Using and customizing policies
+
+Whit this component you can define custom policy sets, containing Roles and RoleBindings, that can be applied to namespaces using labels.
+
+== Applying custom policies to a namespace
+
+Custom policy sets can be applied by labeling the namespace with a `set.rbac.syn.tools/<policy-set-name>: ""` label.
+Where `<policy-set-name>` corresponds to the name of the policy set defined in the component configuration.
+The label value is ignored and can be an empty string.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+  labels:
+    set.rbac.syn.tools/team-devops: "" <1>
+    set.rbac.syn.tools/team-admin: "" <2>
+----
+<1> This applies the custom `team-devops` policy set to the namespace.
+<2> This applies the custom `team-admin` policy sets to the namespace.
+
+== Customizing Policies
+
+Custom policies can be defined in the component configuration using the `namespaceSync.policies` key.
+These policies can then be grouped into policy sets using the `namespaceSync.policySet` key.
+The resulting sets can be applied to namespaces as described above.
+
+[TIP]
+====
+It is allowed to reference the same policy in multiple policy sets.
+Even if more than one of those policy sets are applied to a namespace, the policy will only be created once.
+====
+
+[source,yaml]
+----
+namespaceSync:
+  policies:
+    role/read-configmaps: <1>
+      rules_:
+        read:
+          apiGroups:
+            - ""
+          resources:
+            - configmaps
+          verbs:
+            - get
+            - list
+            - watch
+            - ~delete
+    rolebinding/read-configmaps: <2>
+      role_: read-configmaps
+      subjects_:
+        serviceaccounts:
+          - null/buzz
+          - ~blib
+    rolebinding/namespace-edit:
+      role_: edit
+      subjects_:
+        groups_:
+          - team-devops
+    rolebinding/namespace-admin:
+      role_: admin
+      subjects_:
+        groups_:
+          - team-admin
+  policySets:
+    default:
+      - ~rolebinding/read-configmaps <3>
+    team-devops:
+      - rolebinding/namespace-edit
+    team-admin:
+      - rolebinding/namespace-admin
+----
+<1> Defines a custom Role named `read-configmaps`.
+The parametrization is explained xref:references/parameters.adoc[here].
+<2> Defines a custom RoleBinding `read-configmaps`.
+The parametrization is explained xref:references/parameters.adoc[here].
+<3> Removes the RoleBinding `read-configmaps` from the `default` policy set.
+Sets are rendered with the commodore https://syn.tools/commodore/reference/commodore-libjsonnet.html#_renderarrayarr[`renderArray(arr)`] function and allows removal of array entries using the `~` operator.
+
+A namespace could be labeled as such to apply the `team-devops` and `team-admin` policy sets:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+  labels:
+    set.network-policies.syn.tools/team-devops: ""
+    set.network-policies.syn.tools/team-admin: ""
+----
+This would apply the `namespace-admin`, and `namespace-edit` RoleBindings to the namespace.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -200,6 +200,68 @@ rbac:
 ----
 
 
+== `namespaceSync`
+
+Configures dynamic Roles and RoleBindings managed by Espejote.
+
+=== `ignoredNames`
+
+[horizontal]
+type:: list of strings
+default:: empty list
+
+A list of namespace names where no Roles or RoleBindings will be created.
+Entries in the list can be removed by adding the entry prefixed with a `~`.
+
+=== `ignoredPrefixes`
+
+[horizontal]
+type:: list of strings
+default:: empty list
+
+A list of namespace name-prefixes where no Roles or RoleBindings will be created.
+Entries in the list can be removed by adding the entry prefixed with a `~`.
+
+=== `labelPrefix` label prefix
+
+[horizontal]
+type:: string
+default:: `set.rbac.syn.tools/`
+
+Custom policy sets can be applied to a namespace by adding a label with this prefix and the name of the policy set as suffix.
+For example, to apply the `team-devops` policy set, add the label `set.rbac.syn.tools/team-devops: ""` to the namespace.
+The label value is ignored and can be an empty string.
+
+=== `policies`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Define Roles and RoleBindings to be used by policy sets.
+
+See xref:_roles_clusterroles[Roles / Clusterroles] or xref:_rolebindings_clusterrolebindings[RoleBindings / ClusterRoleBindings] for parametrization.
+
+[NOTE]
+====
+Make sure to use the prefix Roles with `role/` and RoleBindings with `rolebinding/` when defining policies.
+====
+
+Also see xref:how-tos/using-customizing-policies.adoc[].
+
+== `policySets`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Define policy sets that can be selected by the label `set.rbac.syn.tools/<policy-set-name>: ""`.
+A policy set is an array of policy names defined in `policies`.
+Names can be removed from the default policy sets by prefixing them with a `~`.
+A policy can be part of multiple policy sets, even if those policy sets are applied to the same namespace.
+
+Also see xref:how-tos/using-customizing-policies.adoc[].
+
 
 == Example
 

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,4 +1,16 @@
+applications:
+  - espejote
+
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
+  espejote:
+    namespace: syn-espejote
+
   rbac:
     namespace: syn-serviceaccounts
     manageNamespace: true
@@ -92,3 +104,28 @@ parameters:
           groups:
             - org
             - ~root
+
+    namespaceSync:
+      policies:
+        role/read-configmaps:
+          rules_:
+            read:
+              apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - ~delete
+        rolebinding/read-configmaps:
+          role_: read-configmaps
+          subjects_:
+            serviceaccounts:
+              - null/buzz
+              - ~blib
+      policySets:
+        test1:
+          - role/read-configmaps
+          - rolebinding/read-configmaps

--- a/tests/golden/defaults/rbac/rbac/espejote_lib.yaml
+++ b/tests/golden/defaults/rbac/rbac/espejote_lib.yaml
@@ -1,0 +1,84 @@
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: espejote-rbac-sync
+  name: espejote-rbac-sync
+  namespace: syn-espejote
+spec:
+  data:
+    config.json: |-
+      {
+          "ignoreNames": [
+
+          ],
+          "ignorePrefixes": [
+
+          ],
+          "labelPrefix": "set.rbac.syn.tools/",
+          "policies": {
+              "role/read-configmaps": {
+                  "apiVersion": "rbac.authorization.k8s.io/v1",
+                  "kind": "Role",
+                  "metadata": {
+                      "annotations": {
+                          "syn.tools/source": "https://github.com/projectsyn/component-rbac.git"
+                      },
+                      "labels": {
+                          "app.kubernetes.io/component": "rbac",
+                          "app.kubernetes.io/managed-by": "espejote",
+                          "app.kubernetes.io/part-of": "syn"
+                      },
+                      "name": "read-configmaps"
+                  },
+                  "rules": [
+                      {
+                          "apiGroups": [
+                              ""
+                          ],
+                          "resources": [
+                              "configmaps"
+                          ],
+                          "verbs": [
+                              "get",
+                              "list",
+                              "watch"
+                          ]
+                      }
+                  ]
+              },
+              "rolebinding/read-configmaps": {
+                  "apiVersion": "rbac.authorization.k8s.io/v1",
+                  "kind": "RoleBinding",
+                  "metadata": {
+                      "annotations": {
+                          "syn.tools/source": "https://github.com/projectsyn/component-rbac.git"
+                      },
+                      "labels": {
+                          "app.kubernetes.io/component": "rbac",
+                          "app.kubernetes.io/managed-by": "espejote",
+                          "app.kubernetes.io/part-of": "syn"
+                      },
+                      "name": "read-configmaps"
+                  },
+                  "roleRef": {
+                      "apiGroup": "rbac.authorization.k8s.io",
+                      "kind": "Role",
+                      "name": "read-configmaps"
+                  },
+                  "subjects": [
+                      {
+                          "kind": "ServiceAccount",
+                          "name": "buzz",
+                          "namespace": "null"
+                      }
+                  ]
+              }
+          },
+          "policySets": {
+              "test1": [
+                  "role/read-configmaps",
+                  "rolebinding/read-configmaps"
+              ]
+          }
+      }

--- a/tests/golden/defaults/rbac/rbac/espejote_lib.yaml
+++ b/tests/golden/defaults/rbac/rbac/espejote_lib.yaml
@@ -13,7 +13,10 @@ spec:
 
           ],
           "ignorePrefixes": [
-
+              "appuio",
+              "kube",
+              "openshift",
+              "syn"
           ],
           "labelPrefix": "set.rbac.syn.tools/",
           "policies": {

--- a/tests/golden/defaults/rbac/rbac/espejote_mr.yaml
+++ b/tests/golden/defaults/rbac/rbac/espejote_mr.yaml
@@ -1,0 +1,189 @@
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    syn.tools/description: |
+      Manages Roles and RoleBindings based on namespace labels.
+
+      To customize the applied RBAC policies, you can use labels on namespaces to select
+      additional policy sets. See https://hub.syn.tools/rbac/index.html for details.
+  labels:
+    app.kubernetes.io/name: espejote-rbac-sync
+  name: espejote-rbac-sync
+  namespace: syn-espejote
+spec:
+  applyOptions:
+    force: true
+  context:
+    - name: namespaces
+      resource:
+        apiVersion: v1
+        kind: Namespace
+  serviceAccountRef:
+    name: espejote-rbac-sync
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local config = import 'lib/espejote-rbac-sync/config.json';
+
+    local context = esp.context();
+
+    local activePoliciesAnnotation = 'rbac.syn.tools/active-policies';
+
+    // Extract the active policy sets from the given namespace object,
+    // based on the annotations applied by this ManagedResource.
+    local activePolicies(namespace) =
+      local rawSet = std.get(std.get(namespace.metadata, 'annotations', {}), activePoliciesAnnotation, '[]');
+      std.set(std.parseJson(rawSet));
+
+    // Extract the desired policy sets from the given namespace object,
+    // Returns an empty array if the namespace is in the ignoredNamespaces list.
+    // If no policy sets are set by labels, no policy sets are returned.
+    // If any policy set labels are set, those are returned.
+    //   ignoredNamespaces / no-defaults label -> []
+    //   no policy set labels -> [ ]
+    //   policy set labels -> [ <policy sets from labels> ]
+    local desiredPolicySets(namespace) =
+      local objHasLabel(obj, label) =
+        std.objectHas(std.get(obj.metadata, 'labels', {}), label);
+
+      // Policy sets based on labels starting with params.namespaceSync.labelPrefix.
+      //   labels:
+      //     set.example.io/airlock: ""
+      //     set.example.io/myapp: ""
+      // would return the policy sets `["airlock", "myapp"]`.
+      // The configured prefix is suffixed with a '/' if it does not already end with one.
+      local policySetsFromLabel =
+        local prefix = if std.endsWith(config.labelPrefix, '/') then
+          config.labelPrefix
+        else
+          config.labelPrefix + '/';
+
+        [
+          lbl[std.length(prefix):]
+          for lbl in std.objectFields(std.get(namespace.metadata, 'labels', {}))
+          if std.startsWith(lbl, prefix)
+        ];
+
+      if std.member(config.ignoreNames, namespace.metadata.name) then
+        []
+      else if std.length(std.filter(
+        function(prefix) std.startsWith(namespace.metadata.name, prefix),
+        config.ignorePrefixes
+      )) > 0 then
+        []
+      else if std.length(policySetsFromLabel) > 0 then
+        std.set(policySetsFromLabel)
+      else
+        [];
+
+    local isRole(policyName) =
+      std.startsWith(policyName, 'role/');
+    local isRoleBinding(policyName) =
+      std.startsWith(policyName, 'rolebinding/');
+
+    // Generate policy sets.
+    local generatePolicy(policyName, namespace) =
+      config.policies[policyName] {
+        metadata+: {
+          namespace: namespace.metadata.name,
+        },
+      };
+
+    local purgePolicy(policyName, namespace) =
+      esp.markForDelete(generatePolicy(policyName, namespace));
+
+    // Reconcile the given namespace.
+    local reconcileNamespace(namespace) =
+      local desiredPolicies = std.set(std.filter(
+        function(policy) std.get(config.policies, policy) != null,
+        std.flattenArrays([
+          config.policySets[set]
+          for set in desiredPolicySets(namespace)
+          if std.get(config.policySets, set) != null
+        ])
+      ));
+      // Generate array of RBAC policies for the given policy set.
+      [
+        generatePolicy(policy, namespace)
+        for policy in desiredPolicies
+      ]
+      // Generate array of RBAC policies to be deleted for the given policy set.
+      +
+      [
+        purgePolicy(policy, namespace)
+        for policy in std.setDiff(activePolicies(namespace), desiredPolicies)
+      ]
+      // Generate annotation for the given namespace containing the new active policy sets.
+      +
+      [ {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: {
+          annotations: {
+            [activePoliciesAnnotation]: std.manifestJsonMinified(desiredPolicies),
+          },
+          name: namespace.metadata.name,
+        },
+      } ];
+
+    // check if the object is getting deleted by checking if it has
+    // `metadata.deletionTimestamp`.
+    local inDelete(obj) = std.get(obj.metadata, 'deletionTimestamp', '') != '';
+
+    // Do the thing
+    if esp.triggerName() == 'namespace' then (
+      // Handle single namespace update on namespace trigger
+      local nsTrigger = esp.triggerData();
+      // nsTrigger.resource can be null if we're called when the namespace is getting
+      // deleted. If it's not null, we still don't want to do anything when the
+      // namespace is getting deleted.
+      if nsTrigger.resource != null && !inDelete(nsTrigger.resource) then
+        reconcileNamespace(nsTrigger.resource)
+    ) else if esp.triggerName() == 'role' || esp.triggerName() == 'rolebinding' then (
+      // Handle single namespace update on role or rolebinding trigger
+      local namespace = esp.triggerData().resourceEvent.namespace;
+      std.flattenArrays([
+        reconcileNamespace(ns)
+        for ns in context.namespaces
+        if ns.metadata.name == namespace && !inDelete(ns)
+      ])
+    ) else (
+      // Reconcile all namespaces for jsonnetlibrary update or managedresource
+      // reconcile.
+      local namespaces = context.namespaces;
+      std.flattenArrays([
+        reconcileNamespace(ns)
+        for ns in namespaces
+        if !inDelete(ns)
+      ])
+    )
+  triggers:
+    - name: jslib
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: espejote-rbac-sync
+        namespace: syn-espejote
+    - name: namespace
+      watchContextResource:
+        name: namespaces
+    - name: role
+      watchResource:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: rbac
+            app.kubernetes.io/managed-by: espejote
+            app.kubernetes.io/part-of: syn
+        namespace: ''
+    - name: rolebinding
+      watchResource:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: rbac
+            app.kubernetes.io/managed-by: espejote
+            app.kubernetes.io/part-of: syn
+        namespace: ''

--- a/tests/golden/defaults/rbac/rbac/espejote_rbac.yaml
+++ b/tests/golden/defaults/rbac/rbac/espejote_rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/name: espejote-rbac-sync
+  name: espejote-rbac-sync
+  namespace: syn-espejote
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/name: espejote-managedresource-rbac-sync
+  name: espejote-managedresource-rbac-sync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: espejote-rbac-sync
+    namespace: syn-espejote


### PR DESCRIPTION
Use Espejote ManagedResource to dynamically create RoleBindings.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
